### PR TITLE
bump-nois-crate-to-v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "nois"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b4f3482c5e189a5a51eb2ae3e54ddd58e7f5f63a3cb176b2d6f8709a875ce2"
+checksum = "3f2f7aff53bda03e2f301e6a53aa4e76bb992b599c3163a3f18c1d3169e6341a"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/double-dice-roll/Cargo.toml
+++ b/contracts/double-dice-roll/Cargo.toml
@@ -27,7 +27,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-nois = "0.6.0"
+nois = "0.7.0"
 
 cosmwasm-std = "1.2.3"
 cosmwasm-schema = "1.2.3"


### PR DESCRIPTION
We receive a new field in the Nois beacon callback packet. and that is drand publish time. 
This is not a tendermint block time but a drand calculated time.